### PR TITLE
chore(go): use go 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.17
 
-RUN go get github.com/cespare/reflex
+RUN go install github.com/cespare/reflex@latest
 ADD . /go/src/github.com/Scalingo/sample-go-martini
 WORKDIR /go/src/github.com/Scalingo/sample-go-martini
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16
+FROM golang:1.17
 
 RUN go get github.com/cespare/reflex
 ADD . /go/src/github.com/Scalingo/sample-go-martini

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,11 @@ module github.com/Scalingo/sample-go-martini
 go 1.17
 
 require (
-	github.com/codegangsta/inject v0.0.0-20140630231407-4b8172520a03 // indirect
 	github.com/go-martini/martini v0.0.0-20150420183116-d39885924ac2
 	github.com/martini-contrib/render v0.0.0-20140708150504-b65063311fac
+)
+
+require (
+	github.com/codegangsta/inject v0.0.0-20140630231407-4b8172520a03 // indirect
 	github.com/oxtoacart/bpool v0.0.0-20140610012239-0f78ff9152c0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/Scalingo/sample-go-martini
 
-// +scalingo goVersion go1.16
-go 1.16
+// +scalingo goVersion go1.17
+go 1.17
 
 require (
 	github.com/codegangsta/inject v0.0.0-20140630231407-4b8172520a03 // indirect


### PR DESCRIPTION
The fix for CVE-2022-29526 is only available in Go 1.17 and 1.18.